### PR TITLE
monsters use skills, can now reset game, vision potions seems to work, health potion fix

### DIFF
--- a/src/model/DungeonLogic.java
+++ b/src/model/DungeonLogic.java
@@ -51,25 +51,30 @@ public final class DungeonLogic {
     private void startGame() throws SQLException {
         myFloorLevel = 1;
         setGameActive(true);
-        myFloor = new Floor(myFloorLevel, DUNGEON_SIZE);
-        myInventory = new Inventory();
-        final Room startingRoom = myFloor.getStartingRoom();
-        myCurrentRoom = startingRoom;
-        myLastRoom = startingRoom;
-        reveal(myCurrentRoom);
+        reset();
     }
 
     public void changeFloor() throws SQLException {
         myFloorLevel++;
+        myHero.levelUp();
+        sendMessage("You levelled up!");
+        myChanges.firePropertyChange("LEVEL UP", null,myHero.getMaxHP());
+        Inventory inv = myInventory;
+        reset();
+        myInventory = inv;
+    }
+    public void reset() throws SQLException {
         myFloor = new Floor(myFloorLevel, DUNGEON_SIZE);
         final Room startingRoom = myFloor.getStartingRoom();
-        myHero.levelUp();
         startingRoom.addCharacter(myHero);
         myHeroCol = startingRoom.getCol();
         myHeroRow = startingRoom.getRow();
         myCurrentRoom = startingRoom;
-        reveal(myCurrentRoom);
+        myLastRoom = myCurrentRoom;
+        explore(myCurrentRoom);
+        myInventory = new Inventory();
         myChanges.firePropertyChange("Dir",null,true);
+        myChanges.firePropertyChange("UPDATE MAP",null,true);
     }
 
     public void createCharacter(final String theName, final int theClass) throws SQLException {
@@ -91,8 +96,8 @@ public final class DungeonLogic {
 
     public void setGameActive(final boolean theState) {
         myGameActive = theState;
+        myChanges.firePropertyChange("GAME STATE", !theState, theState);
         if (theState) {
-            myChanges.firePropertyChange("Can Save", false, true);
             myChanges.firePropertyChange("UPDATE MAP", false, true);
         }
     }
@@ -124,17 +129,20 @@ public final class DungeonLogic {
 
     public Set<Room> getNeighbors(final Room theRoom) {
         final Set<Room> set = new HashSet<>();
-        if (theRoom.canWalkNorth()) {
-            set.add(theRoom.getNorth());
+        Room[][] rooms = myFloor.getRooms();
+        int row = theRoom.getRow();
+        int col = theRoom.getCol();
+        if (row > 0) {
+            set.add(rooms[row - 1][col]);
         }
-        if (theRoom.canWalkSouth()) {
-            set.add(theRoom.getSouth());
+        if (row < myFloor.getSize() - 1) {
+            set.add(rooms[row + 1][col]);
         }
-        if (theRoom.canWalkWest()) {
-            set.add(theRoom.getWest());
+        if (col > 0) {
+            set.add(rooms[row][col - 1]);
         }
-        if (theRoom.canWalkEast()) {
-            set.add(theRoom.getEast());
+        if (col < myFloor.getSize() - 1) {
+            set.add(rooms[row][col + 1]);
         }
         return set;
     }
@@ -161,19 +169,35 @@ public final class DungeonLogic {
     public void endCombat() {
         if (myGameActive && myCombatStatus) {
             myCombatStatus = false;
-            reveal(myCurrentRoom);
+            explore(myCurrentRoom);
             myMessages.append("You defeated the enemy!\n");
             trimMessage();
             myChanges.firePropertyChange("MESSAGE", null, myMessages);
             myChanges.firePropertyChange("COMBAT STATUS", !myCombatStatus, myCombatStatus);
+            myChanges.firePropertyChange("Dir", false, true);
         }
     }
 
-    public void reveal(final Room theRoom) {
+    public void explore(final Room theRoom) {
         if (theRoom == null) {
             throw new IllegalArgumentException("The Room is null.");
         }
         theRoom.setExplored(true);
+        theRoom.setVisibilty(true);
+    }
+    public void reveal(final Room theRoom) {
+        if (theRoom == null) {
+            throw new IllegalArgumentException("The Room is null.");
+        }
+        theRoom.setVisibilty(true);
+    }
+    public void expireVisPot() {
+        Set<Room> rooms = getNeighbors(myCurrentRoom);
+        for (Room r: rooms) {
+            if(!r.isExplored()) {
+                r.setVisibilty(false);
+            }
+        }
     }
 
     private boolean outOfBounds(final int thePosition) {
@@ -212,56 +236,60 @@ public final class DungeonLogic {
     public void moveUp() {
         if (myCurrentRoom.canWalkNorth() && !myCombatStatus) {
             myLastRoom = myCurrentRoom;
+            expireVisPot();
             myCurrentRoom.removeCharacter(myHero);
             myCurrentRoom.getNorth().addCharacter(myHero);
             myCurrentRoom = myCurrentRoom.getNorth();
             myHeroCol = myCurrentRoom.getCol();
             myHeroRow = myCurrentRoom.getRow();
-            reveal(myCurrentRoom);
+            explore(myCurrentRoom);
+            myChanges.firePropertyChange("Dir", null,true);
             applyEffects();
-            myChanges.firePropertyChange("North", null,true);
         }
     }
 
     public void moveRight() {
         if (myCurrentRoom.canWalkEast() && !myCombatStatus) {
             myLastRoom = myCurrentRoom;
+            expireVisPot();
             myCurrentRoom.removeCharacter(myHero);
             myCurrentRoom.getEast().addCharacter(myHero);
             myCurrentRoom = myCurrentRoom.getEast();
             myHeroCol = myCurrentRoom.getCol();
             myHeroRow = myCurrentRoom.getRow();
-            reveal(myCurrentRoom);
+            explore(myCurrentRoom);
+            myChanges.firePropertyChange("Dir", null,true);
             applyEffects();
-            myChanges.firePropertyChange("East", null,true);
         }
     }
 
     public void moveDown() {
         if (myCurrentRoom.canWalkSouth() && !myCombatStatus) {
             myLastRoom = myCurrentRoom;
+            expireVisPot();
             myCurrentRoom.removeCharacter(myHero);
             myCurrentRoom.getSouth().addCharacter(myHero);
             myCurrentRoom = myCurrentRoom.getSouth();
             myHeroCol = myCurrentRoom.getCol();
             myHeroRow = myCurrentRoom.getRow();
-            reveal(myCurrentRoom);
+            explore(myCurrentRoom);
+            myChanges.firePropertyChange("Dir", null,true);
             applyEffects();
-            myChanges.firePropertyChange("South", null,true);
         }
     }
 
     public void moveLeft() {
         if (myCurrentRoom.canWalkWest() && !myCombatStatus) {
             myLastRoom = myCurrentRoom;
+            expireVisPot();
             myCurrentRoom.removeCharacter(myHero);
             myCurrentRoom.getWest().addCharacter(myHero);
             myCurrentRoom = myCurrentRoom.getWest();
             myHeroCol = myCurrentRoom.getCol();
             myHeroRow = myCurrentRoom.getRow();
-            reveal(myCurrentRoom);
+            explore(myCurrentRoom);
+            myChanges.firePropertyChange("Dir", null,true);
             applyEffects();
-            myChanges.firePropertyChange("West", null,true);
         }
     }
 
@@ -342,7 +370,6 @@ public final class DungeonLogic {
         if (theMessage == null) {
             throw new NullPointerException("The message is null!");
         }
-
         myMessages.append(theMessage);
         trimMessage();
         myChanges.firePropertyChange("MESSAGE", null, myMessages);

--- a/src/model/Floor.java
+++ b/src/model/Floor.java
@@ -113,19 +113,20 @@ public final class Floor {
                 }
             }
         }
+        chosenRoom.emptyRoom();
         addPillar(chosenRoom);
         chosenRoom.addCharacter(MonsterFactory.createBoss(myFloorLevel));
         return startingRoom;
     }
 
     private void addPillar(final Room theRoom) {
-        if (myFloorLevel == 0) {
+        if (myFloorLevel == 1) {
             theRoom.addItem(new Pillar("Encapsulation"));
-        } else if (myFloorLevel == 1) {
-            theRoom.addItem(new Pillar("Polymorphism"));
         } else if (myFloorLevel == 2) {
-            theRoom.addItem(new Pillar("Inheritance"));
+            theRoom.addItem(new Pillar("Polymorphism"));
         } else if (myFloorLevel == 3) {
+            theRoom.addItem(new Pillar("Inheritance"));
+        } else if (myFloorLevel == 4) {
             theRoom.addItem(new Pillar("Abstraction"));
         }
     }
@@ -259,7 +260,7 @@ public final class Floor {
                         break;
                     }
                 }
-//                if (r.isExplored()) {
+                if (r.isVisible()) {
                     if (hasHero) {
                         sb.append('@');
                     } else if (hasMonster) {
@@ -269,9 +270,9 @@ public final class Floor {
                     } else {
                         sb.append(' ');
                     }
-//                } else {
-//                    sb.append('?');
-//                }
+                } else {
+                    sb.append('?');
+                }
             }
 
             if (myRooms[row][mySize - 1].canWalkEast()) {

--- a/src/model/HealthPotion.java
+++ b/src/model/HealthPotion.java
@@ -12,8 +12,7 @@ public final class HealthPotion extends AbstractConsumable {
     public void triggerEffect() {
         super.triggerEffect();
         final Hero hero = DungeonLogic.MY_INSTANCE.getHero();
-        int heal = Math.min(hero.getMaxHP() / 2 + hero.getHP(), hero.getMaxHP() - hero.getHP());
-        hero.healOrDamage(heal);
+        hero.healOrDamage(hero.getMaxHP() / 2);
     }
     @Override
     public String toString() {

--- a/src/model/Mage.java
+++ b/src/model/Mage.java
@@ -19,6 +19,6 @@ public final class Mage extends Hero {
 
     @Override
     public String skillDescription() {
-        return "model.Mage heals itself.";
+        return super.getMyClass() + " heals itself.";
     }
 }

--- a/src/model/Monster.java
+++ b/src/model/Monster.java
@@ -18,8 +18,14 @@ public final class Monster extends AbstractDungeonCharacter {
     }
     @Override
     public String skill(final AbstractDungeonCharacter theTarget) {
-//        theTarget.healOrDamage((int) (myHP * myHealMultiplier));
-        return "";
+        if (Math.random() <= myHealRate) {
+            int healAmount = (int) (myHP * myHealMultiplier);
+            theTarget.healOrDamage(healAmount);
+            return myName + "healed " + healAmount + " HP!";
+        }
+        else {
+            return "";
+        }
     }
 
     @Override

--- a/src/model/Rogue.java
+++ b/src/model/Rogue.java
@@ -15,7 +15,6 @@ public final class Rogue extends Hero {
     public String skill(final AbstractDungeonCharacter theTarget) {
         setAtkSpd((int) (getAtkSpd() * 1.5));
         theTarget.setHitChance(getHitChance() - 20);
-System.out.println("Remember to set hit chance back after skill duration expires.");
 
         String result = attack(theTarget);
 
@@ -26,6 +25,6 @@ System.out.println("Remember to set hit chance back after skill duration expires
 
     @Override
     public String skillDescription() {
-        return "model.Rogue gets haste and is able to attack faster and dodge more.";
+        return super.getMyClass() + " gets haste and is able to attack faster and dodge more.";
     }
 }

--- a/src/model/Room.java
+++ b/src/model/Room.java
@@ -15,6 +15,7 @@ public final class Room {
     private Room mySouthRoom;
     private Room myWestRoom;
     private boolean myExplored;
+    private boolean myVisible;
 
     private Room() {
         this(0, 0);
@@ -26,6 +27,7 @@ public final class Room {
         myRow = theRow;
         myCol = theCol;
         myExplored = false;
+        myVisible = false;
     }
 
     Room(final Room theNorthRoom, final Room theEastRoom, final Room theSouthRoom, final Room theWestRoom, final int theRow, final int theCol) {
@@ -45,12 +47,17 @@ public final class Room {
         return myItems;
     }
 
-    public final boolean isExplored() {
+    public boolean isVisible() {
+        return myVisible;
+    }
+    public boolean isExplored() {
         return myExplored;
     }
-
     public void setExplored(final boolean theState) {
         myExplored = theState;
+    }
+    public void setVisibilty(final boolean theState) {
+        myVisible = theState;
     }
     public void addCharacter(final AbstractDungeonCharacter theCharacter) {
         myDungeonCharacters.add(theCharacter);

--- a/src/model/Warrior.java
+++ b/src/model/Warrior.java
@@ -26,6 +26,6 @@ public final class Warrior extends Hero {
 
     @Override
     public String skillDescription() {
-        return "model.Warrior performs a giant haphazard swing at the monster";
+        return super.getMyClass() + " performs a giant haphazard swing at the monster";
     }
 }


### PR DESCRIPTION
Controller: 
     optimized fight() a little
      monsters now use skill in the fight
      set myGameActive to false when game ends
      Added listener to Vision potion use
      Removed myInventory Field

Logic: 
     startGame and changeFloor have repeated code, so made reset() for that code as it is now also used to reset the gameboard
      listener Can Save now changed to GAME STATE that handles disabling and enabling buttons on game initialization and end
      getNeighbors changed to obtain all neighbors instead of only connecting neighbors
      added an explore method to differentiate revealed rooms and explored rooms
      added Visibility potion effect expiring when travelling to a new room
      All property change fires from moving is consolidated

View:
     Added window for invalid name input
     Added action listener to Vision Potion
     property listener Can Save now changed to GAME STATE and encompasses all relevant buttons on game start and end
     property listeners for directions now consolidated into Dir
     Added new property listener for levelling up

Floor:
     Fixed bug where pillars were adding onto the wrong floors
     uncommented code to make map contents invisible to the player until explored of revealed

HealthPotion:
     fixed a bug where health potions were healing more than intended

Hero subclasses: updated skillDescription

Monster: updated skill to perform as intended

Room: 
     Added new field myVisible
      Explored rooms will always be visible, but visible rooms will become invisible once vision potions expire if not yet explored
      Added getters and setters for myVisible